### PR TITLE
chore: update .gitignore to exclude additional build and temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@
 /api/index.js
 /api/index.js.map
 /app/styles/tailwind.css
+.netlify
+.vercel
+.remix
+/server-build
 
 # Environment variables
 .env
@@ -57,3 +61,15 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Temporary files
+*.swp
+*.swo
+*~
+.temp
+.tmp
+
+# Vite specific
+/.vite
+/vite.config.js.timestamp-*
+/vite.config.ts.timestamp-*


### PR DESCRIPTION
Add entries for .netlify, .vercel, .remix, /server-build, and Vite-specific files to prevent them from being tracked by Git. Also, include temporary file patterns to keep the repository clean.